### PR TITLE
feat!: add presentation frame

### DIFF
--- a/example/vc.ts
+++ b/example/vc.ts
@@ -41,49 +41,51 @@ const verifyCb: Verifier = ({ header, message, signature }) => {
 const saltGenerator: SaltGenerator = () =>
     getRandomValues(Buffer.alloc(16)).toString('base64url')
 
+const payload = {
+    '@context': [
+        'https://www.w3.org/2018/credentials/v1',
+        'https://w3id.org/citizenship/v1',
+        'https://w3id.org/security/bbs/v1'
+    ],
+    id: 'https://issuer.oidp.uscis.gov/credentials/83627465',
+    vct: ['VerifiableCredential', 'PermanentResidentCard'],
+    issuer: 'did:key:zUC74VEqqhEHQcgv4zagSPkqFJxuNWuoBPKjJuHETEUeHLoSqWt92viSsmaWjy82y2cgguc8e9hsGBifnVK67pQ4gve3m6iSboDkmJjxVEb1d6mRAx5fpMAejooNzNqqbTMVeUN',
+    identifier: '83627465',
+    name: 'Permanent Resident Card',
+    description: 'Government of Example Permanent Resident Card.',
+    issuanceDate: '2019-12-03T12:19:52Z',
+    expirationDate: '2029-12-03T12:19:52Z',
+    credentialSubject: {
+        id: 'did:example:b34ca6cd37bbf23',
+        type: ['PermanentResident', 'Person'],
+        givenName: 'JOHN',
+        familyName: 'SMITH',
+        gender: 'Male',
+        image: 'data:image/png;base64,iVBORw0KGgokJggg==',
+        residentSince: '2015-01-01',
+        lprCategory: 'C09',
+        lprNumber: '999-999-999',
+        commuterClassification: 'C1',
+        birthCountry: 'Bahamas',
+        birthDate: '1958-07-17'
+    },
+    proof: {
+        type: 'BbsBlsSignature2020',
+        created: '2022-04-13T13:47:47Z',
+        verificationMethod:
+            'did:key:zUC74VEqqhEHQcgv4zagSPkqFJxuNWuoBPKjJuHETEUeHLoSqWt92viSsmaWjy82y2cgguc8e9hsGBifnVK67pQ4gve3m6iSboDkmJjxVEb1d6mRAx5fpMAejooNzNqqbTMVeUN#zUC74VEqqhEHQcgv4zagSPkqFJxuNWuoBPKjJuHETEUeHLoSqWt92viSsmaWjy82y2cgguc8e9hsGBifnVK67pQ4gve3m6iSboDkmJjxVEb1d6mRAx5fpMAejooNzNqqbTMVeUN',
+        proofPurpose: 'assertionMethod',
+        proofValue:
+            'hoNNnnRIoEoaY9Fvg3pGVG2eWTAHnR1kIM01nObEL2FdI2IkkpM3246jn3VBD8KBYUHlKfzccE4m7waZyoLEkBLFiK2g54Q2i+CdtYBgDdkUDsoULSBMcH1MwGHwdjfXpldFNFrHFx/IAvLVniyeMQ=='
+    }
+} as const
+
 const issuer = async () => {
     console.log('====== ISSUER ======')
 
     const sdJwt = new SdJwt({
         header: { alg: SignatureAndEncryptionAlgorithm.EdDSA },
-        payload: {
-            '@context': [
-                'https://www.w3.org/2018/credentials/v1',
-                'https://w3id.org/citizenship/v1',
-                'https://w3id.org/security/bbs/v1'
-            ],
-            id: 'https://issuer.oidp.uscis.gov/credentials/83627465',
-            vct: ['VerifiableCredential', 'PermanentResidentCard'],
-            issuer: 'did:key:zUC74VEqqhEHQcgv4zagSPkqFJxuNWuoBPKjJuHETEUeHLoSqWt92viSsmaWjy82y2cgguc8e9hsGBifnVK67pQ4gve3m6iSboDkmJjxVEb1d6mRAx5fpMAejooNzNqqbTMVeUN',
-            identifier: '83627465',
-            name: 'Permanent Resident Card',
-            description: 'Government of Example Permanent Resident Card.',
-            issuanceDate: '2019-12-03T12:19:52Z',
-            expirationDate: '2029-12-03T12:19:52Z',
-            credentialSubject: {
-                id: 'did:example:b34ca6cd37bbf23',
-                type: ['PermanentResident', 'Person'],
-                givenName: 'JOHN',
-                familyName: 'SMITH',
-                gender: 'Male',
-                image: 'data:image/png;base64,iVBORw0KGgokJggg==',
-                residentSince: '2015-01-01',
-                lprCategory: 'C09',
-                lprNumber: '999-999-999',
-                commuterClassification: 'C1',
-                birthCountry: 'Bahamas',
-                birthDate: '1958-07-17'
-            },
-            proof: {
-                type: 'BbsBlsSignature2020',
-                created: '2022-04-13T13:47:47Z',
-                verificationMethod:
-                    'did:key:zUC74VEqqhEHQcgv4zagSPkqFJxuNWuoBPKjJuHETEUeHLoSqWt92viSsmaWjy82y2cgguc8e9hsGBifnVK67pQ4gve3m6iSboDkmJjxVEb1d6mRAx5fpMAejooNzNqqbTMVeUN#zUC74VEqqhEHQcgv4zagSPkqFJxuNWuoBPKjJuHETEUeHLoSqWt92viSsmaWjy82y2cgguc8e9hsGBifnVK67pQ4gve3m6iSboDkmJjxVEb1d6mRAx5fpMAejooNzNqqbTMVeUN',
-                proofPurpose: 'assertionMethod',
-                proofValue:
-                    'hoNNnnRIoEoaY9Fvg3pGVG2eWTAHnR1kIM01nObEL2FdI2IkkpM3246jn3VBD8KBYUHlKfzccE4m7waZyoLEkBLFiK2g54Q2i+CdtYBgDdkUDsoULSBMcH1MwGHwdjfXpldFNFrHFx/IAvLVniyeMQ=='
-            }
-        }
+        payload
     })
         .withHasher(hasherAndAlgorithm)
         .withSigner(signer)
@@ -133,7 +135,9 @@ const issuer = async () => {
 const holder = async (compact: string) => {
     console.log('====== HOLDER ======')
 
-    const sdJwt = SdJwt.fromCompact(compact).withHasher(hasherAndAlgorithm)
+    const sdJwt = SdJwt.fromCompact<Record<string, unknown>, typeof payload>(
+        compact
+    ).withHasher(hasherAndAlgorithm)
 
     console.log('Claims: ')
     console.log('========')
@@ -141,7 +145,21 @@ const holder = async (compact: string) => {
     console.log('========')
     console.log()
 
-    const presentation = await sdJwt.present([0, 1, 6])
+    const presentationFrame = {
+        credentialSubject: {
+            image: true,
+            gender: true,
+            birthCountry: true
+        }
+    } as const
+
+    console.log('Presentation Frame:')
+    console.log('========')
+    console.log(presentationFrame)
+    console.log('========')
+    console.log()
+
+    const presentation = await sdJwt.present(presentationFrame)
 
     console.log('Presenting: ')
     console.log('============')

--- a/src/sdJwt/disclosureFrame.ts
+++ b/src/sdJwt/disclosureFrame.ts
@@ -126,7 +126,7 @@ export const applyDisclosureFrame = async <
     }
 
     const payloadClone = { ...payload }
-    cleanup.forEach((path) => deleteByPath(payloadClone, path.join('.')))
+    cleanup.forEach((path) => deleteByPath(payloadClone, path))
 
     return { payload: payloadClone, disclosures }
 }

--- a/src/sdJwt/disclosureMapping.ts
+++ b/src/sdJwt/disclosureMapping.ts
@@ -1,0 +1,242 @@
+// This file contains helpers functions for mapping between disclosures entries and the payload of an SD-JWT.
+
+import { Hasher } from '../types'
+import { isObject, traverseNodes } from '../utils'
+import { Disclosure } from './disclosures'
+import { SdJwtError } from './error'
+
+/**
+ * Mapping from a digest to the corresponding disclosure and its parent disclosures.
+ */
+export type DisclosureMap = {
+    [digest: string]: {
+        disclosure: Disclosure
+        parentDisclosures: Disclosure[]
+    }
+}
+
+const getArrayPayloadDisclosureMapping = (
+    array: Array<unknown>,
+    map: DisclosureMap
+) => {
+    const arrayPayloadDisclosureMapping: any[] = []
+
+    for (const item of array) {
+        if (item instanceof Object) {
+            // if Array item is { '...': <SD_HASH_DIGEST> }
+            if ('...' in item) {
+                const digest = item['...']
+                if (typeof digest !== 'string') {
+                    throw new SdJwtError(
+                        `Expected value of '...' to be of type string, but found ${typeof digest}`
+                    )
+                }
+                const disclosed = map[digest]
+
+                if (disclosed) {
+                    const value = [...disclosed.disclosure.decoded].pop()
+
+                    if (isObject(value)) {
+                        const unpacked = getPayloadDisclosureMapping(value, map)
+
+                        if (Object.keys(unpacked).length > 0) {
+                            arrayPayloadDisclosureMapping.push({
+                                ...unpacked,
+                                __digest: digest
+                            })
+                        } else {
+                            arrayPayloadDisclosureMapping.push(digest)
+                        }
+                    } else if (Array.isArray(value)) {
+                        const nestedUnpackedArray =
+                            getArrayPayloadDisclosureMapping(value, map)
+
+                        if (
+                            nestedUnpackedArray.every((item) => item === null)
+                        ) {
+                            arrayPayloadDisclosureMapping.push(digest)
+                        } else {
+                            arrayPayloadDisclosureMapping.push(
+                                nestedUnpackedArray
+                            )
+                        }
+                    } else {
+                        arrayPayloadDisclosureMapping.push(digest)
+                    }
+                }
+            } else {
+                // unpack recursively
+                const claims = getPayloadDisclosureMapping(item, map)
+                if (Object.keys(claims).length > 0) {
+                    arrayPayloadDisclosureMapping.push(claims)
+                } else {
+                    arrayPayloadDisclosureMapping.push(null)
+                }
+            }
+        } else {
+            arrayPayloadDisclosureMapping.push(null)
+        }
+    }
+
+    return arrayPayloadDisclosureMapping
+}
+
+/**
+ * Get a mapping in the structure of the pretty payload, to indicate which digests should be disclosed for a
+ * given entry.
+ *
+ * @example
+ * {
+ *    "name": "<digest-name>"
+ * }
+ *
+ * In the above example you now know that to reveal "name", you must include "<digest-name>"
+ */
+export function getPayloadDisclosureMapping(payload: any, map: DisclosureMap) {
+    if (payload instanceof Array) {
+        return getArrayPayloadDisclosureMapping(payload, map)
+    }
+
+    if (!isObject(payload)) {
+        return {}
+    }
+
+    const payloadDisclosureMapping: Record<string, unknown> = {}
+    for (const key in payload) {
+        // if obj property value is an object or array
+        // recursively unpack
+        if (key !== '_sd' && key !== '...' && payload[key] instanceof Object) {
+            const claim = getPayloadDisclosureMapping(payload[key], map)
+            if (Object.keys(claim).length > 0) {
+                payloadDisclosureMapping[key] = claim
+            }
+        }
+    }
+
+    if (payload._sd) {
+        if (!Array.isArray(payload._sd)) {
+            throw new SdJwtError(
+                `Expect value of '_sd' to be of type array, but found ${typeof payload._sd}`
+            )
+        }
+
+        for (const digest of payload._sd) {
+            if (typeof digest !== 'string') {
+                throw new SdJwtError(
+                    `Expected entries in '_sd' property to be of type string, found ${typeof digest}`
+                )
+            }
+
+            const disclosed = map[digest]
+
+            if (disclosed) {
+                const value = [...disclosed.disclosure.decoded].pop()
+                if (disclosed.disclosure.decoded.length !== 3) {
+                    throw new SdJwtError(
+                        `Expected disclosure for value ${value} to have 3 items, but found ${disclosed.disclosure.decoded.length}`
+                    )
+                }
+                const key = disclosed.disclosure.decoded[1]
+
+                // This should check if there's a nested disclosure anywhere down the tree
+                if (isObject(value)) {
+                    const unpacked = getPayloadDisclosureMapping(value, map)
+                    if (Object.keys(unpacked).length > 0) {
+                        payloadDisclosureMapping[key] = {
+                            ...unpacked,
+                            __digest: digest
+                        }
+                    } else {
+                        payloadDisclosureMapping[key] = digest
+                    }
+                } else if (Array.isArray(value)) {
+                    payloadDisclosureMapping[key] = getPayloadDisclosureMapping(
+                        value,
+                        map
+                    )
+                } else {
+                    payloadDisclosureMapping[key] = digest
+                }
+            }
+        }
+    }
+
+    return payloadDisclosureMapping
+}
+
+// @todo it would ben nice if we don't have to pass hasher around everywhere
+// but have a Disclosure type that includes the digest
+const getParentDisclosure = async (
+    disclosure: Disclosure,
+    digestMap: Record<string, Disclosure>,
+    hasher: Hasher
+): Promise<Disclosure[]> => {
+    const parent = digestMap[await disclosure.digest(hasher)]
+
+    if (!parent) {
+        return []
+    }
+
+    if (digestMap[await parent.digest(hasher)]) {
+        return [parent].concat(
+            await getParentDisclosure(parent, digestMap, hasher)
+        )
+    }
+
+    return [parent]
+}
+
+/**
+ * Get a mapping from a digest to the corresponding disclosure and its parent disclosures.
+ */
+export const getDisclosureMap = async (
+    disclosures: Disclosure[],
+    hasher: Hasher
+): Promise<DisclosureMap> => {
+    const map: DisclosureMap = {}
+    const parentMap: Record<string, Disclosure> = {}
+
+    for (const disclosure of disclosures) {
+        // value is always the last item in the disclosure array
+        const value = [...disclosure.decoded].pop()
+
+        traverseNodes(value).forEach(({ path, value }) => {
+            const lastPathItem = path[path.length - 1]
+
+            if (lastPathItem === '_sd') {
+                if (!Array.isArray(value)) {
+                    throw new SdJwtError(
+                        `Expect value of '_sd' to be of type array, but found ${typeof value}`
+                    )
+                }
+
+                value.forEach((digest) => {
+                    if (typeof digest !== 'string') {
+                        throw new SdJwtError(
+                            `Expected entries in '_sd' property to be of type string, found ${typeof digest}`
+                        )
+                    }
+                    parentMap[digest] = disclosure
+                })
+            } else if (lastPathItem === '...') {
+                if (typeof value !== 'string') {
+                    throw new SdJwtError(
+                        `Expected value of '...' to be of type string, but found ${typeof value}`
+                    )
+                }
+                parentMap[value] = disclosure
+            }
+        })
+    }
+
+    for (const disclosure of disclosures) {
+        const parent = await getParentDisclosure(disclosure, parentMap, hasher)
+
+        map[await disclosure.digest(hasher)] = {
+            disclosure,
+            parentDisclosures: parent
+        }
+    }
+
+    return map
+}

--- a/src/sdJwt/disclosures.ts
+++ b/src/sdJwt/disclosures.ts
@@ -6,6 +6,7 @@ export class Disclosure {
     private salt: string
     private key?: string
     private value: unknown
+    private _digest: string | undefined
 
     public constructor(salt: string, value: unknown, key?: string) {
         if (typeof value === 'number' && isNaN(value)) {
@@ -48,8 +49,13 @@ export class Disclosure {
     }
 
     public async digest(hasher: Hasher) {
-        const hash = await hasher(this.encoded)
-        return Base64url.encode(hash)
+        // Memoize value so we don't have to re-compute
+        if (!this._digest) {
+            const hash = await hasher(this.encoded)
+            this._digest = Base64url.encode(hash)
+        }
+
+        return this._digest
     }
 
     public toString() {

--- a/src/sdJwt/presentationFrame.ts
+++ b/src/sdJwt/presentationFrame.ts
@@ -1,0 +1,93 @@
+import { getByPath, hasByPath, traverseNodes } from '../utils'
+import { Disclosure } from './disclosures'
+import { SdJwtError } from './error'
+import { Hasher } from '../types'
+import { PresentationFrame } from '../types/present'
+import {
+    getDisclosureMap,
+    getPayloadDisclosureMapping
+} from './disclosureMapping'
+
+export const getDisclosuresForPresentationFrame = async <
+    Payload extends Record<string, unknown> = Record<string, unknown>
+>(
+    signedPayload: Payload,
+    presentationFrame: PresentationFrame<Payload>,
+    prettyClaims: Payload,
+    hasher: Hasher,
+    disclosures: Array<Disclosure> = []
+): Promise<Array<Disclosure>> => {
+    const requiredDisclosureDigests = new Set<string>()
+    const disclosureMap = await getDisclosureMap(disclosures, hasher)
+    const payloadDisclosureMapping = getPayloadDisclosureMapping(
+        signedPayload,
+        disclosureMap
+    )
+
+    for (const node of traverseNodes(presentationFrame)) {
+        // We only want to process leaf nodes here
+        if (!node.isLeaf) continue
+
+        if (typeof node.value !== 'boolean') {
+            throw new SdJwtError(
+                `Expected leaf value in presentation frame to be of type boolean, but found ${typeof node.value}`
+            )
+        }
+
+        // If the value is false, it means we don't want to disclose it
+        if (node.value === false) continue
+
+        // FIXME: we should check whether the presentation frame matches the type of the payload. So if the presentation frame has an array as value, but the pretty payload
+        // has a number it should throw an error
+        if (!hasByPath(prettyClaims, node.path)) {
+            throw new SdJwtError(
+                `Path ${node.path.join(
+                    '.'
+                )} from presentation frame is not present in pretty SD-JWT payload. The presentation frame may only include properties that are present in the SD-JWT payload.`
+            )
+        }
+
+        let path = [...node.path]
+        while (!hasByPath(payloadDisclosureMapping, path)) {
+            if (path.pop() === undefined) break
+        }
+
+        // There are no disclosures on this path, meaning the property is disclosed by default in the signed payload
+        if (path.length === 0) continue
+
+        const disclosure = getByPath(payloadDisclosureMapping, path)
+        // If disclosure is string, it means it's already the digest
+        if (typeof disclosure === 'string')
+            requiredDisclosureDigests.add(disclosure)
+        // Otherwise we want to get all the child digests as well
+        else {
+            for (const nestedItem of traverseNodes(disclosure)) {
+                if (
+                    !nestedItem.isLeaf ||
+                    typeof nestedItem.value !== 'string'
+                ) {
+                    continue
+                }
+                requiredDisclosureDigests.add(nestedItem.value)
+            }
+        }
+    }
+
+    for (const disclosureDigest of requiredDisclosureDigests.values()) {
+        const disclosure = disclosureMap[disclosureDigest]
+
+        if (!disclosure) {
+            throw new Error('disclosure not found')
+        }
+
+        await Promise.all(
+            disclosure.parentDisclosures.map(async (d) =>
+                requiredDisclosureDigests.add(await d.digest(hasher))
+            )
+        )
+    }
+
+    return Array.from(requiredDisclosureDigests).map(
+        (digest) => disclosureMap[digest].disclosure
+    )
+}

--- a/src/types/present.ts
+++ b/src/types/present.ts
@@ -1,0 +1,15 @@
+export type PresentationFrame<T> = T extends Array<unknown>
+    ? {
+          [K in keyof T]?: T[K] extends Record<string | number, unknown>
+              ? PresentationFrame<T[K]> | boolean
+              : boolean
+      }
+    : T extends Record<string, unknown>
+    ? {
+          [K in keyof T]?: T[K] extends Array<unknown>
+              ? PresentationFrame<T[K]> | boolean
+              : T[K] extends Record<string, unknown>
+              ? PresentationFrame<T[K]> | boolean
+              : boolean
+      } & Record<string, unknown>
+    : boolean

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './traverse'
+export * from './utils'

--- a/src/utils/traverse.ts
+++ b/src/utils/traverse.ts
@@ -1,0 +1,39 @@
+export const traverseNodes = (
+    object: any,
+    path: PathNode[] = []
+): LeafNode[] => {
+    const result: LeafNode[] = []
+
+    if (typeof object !== 'object' || object === null) {
+        return [{ path: [], value: object, isLeaf: true }]
+    }
+
+    for (const key in object) {
+        if (object.hasOwnProperty(key)) {
+            const currentPath = [...path, key]
+            const value = object[key as keyof typeof object]
+
+            // Value must be object / array, and have at least some values in it
+            if (
+                typeof value === 'object' &&
+                value !== null &&
+                Object.keys(value).length > 0
+            ) {
+                // Recursively traverse nested objects or arrays
+                result.push(...traverseNodes(value, currentPath))
+            } else {
+                // Leaf node found
+                result.push({ path: currentPath, value, isLeaf: true })
+            }
+        }
+    }
+
+    return result
+}
+
+type PathNode = string | number
+interface LeafNode {
+    path: PathNode[]
+    value: any
+    isLeaf: boolean
+}

--- a/tests/presentationFrame.test.ts
+++ b/tests/presentationFrame.test.ts
@@ -1,0 +1,89 @@
+import { deepStrictEqual } from 'node:assert'
+import { before, describe, it } from 'node:test'
+
+import { prelude } from './utils'
+
+import { getDisclosuresForPresentationFrame } from '../src/sdJwt/presentationFrame'
+import { HasherAlgorithm, SdJwt } from '../src'
+
+describe('presentationFrame', async () => {
+    before(prelude)
+
+    it('disclosure', async () => {
+        const sdJwt = new SdJwt(
+            {
+                header: { alg: 'EdDSA' },
+                payload: {
+                    iss: 'https://example.org/issuer',
+                    nested_field: {
+                        more_nested_field: { a: [1, 2, 3, 4] }
+                    },
+                    credential: {
+                        firstName: 'John',
+                        lastName: 'Doe',
+                        ageOver18: true,
+                        ageOver21: true,
+                        ageOver65: false
+                    },
+                    mustDiscloseWholeObject: {
+                        ifYouWantToDisclose: 'thisKey'
+                    }
+                }
+            },
+            {
+                signer: () => new Uint8Array(32).fill(41),
+                saltGenerator: () => 'salt',
+                disclosureFrame: {
+                    iss: true,
+                    __decoyCount: 1,
+                    nested_field: {
+                        more_nested_field: { a: [true, true, false, true] },
+                        __decoyCount: 5
+                    },
+                    credential: {
+                        ageOver18: true,
+                        ageOver21: true,
+                        ageOver65: true,
+                        firstName: true,
+                        lastName: true
+                    },
+                    mustDiscloseWholeObject: true
+                },
+                hasherAndAlgorithm: {
+                    hasher: (data) => Buffer.from(data),
+                    algorithm: HasherAlgorithm.Sha256
+                }
+            }
+        )
+
+        // NOTE: we need to apply the disclosure frame, otherwise payload is the input payload
+        await sdJwt.applyDisclosureFrame()
+        const disclosures = sdJwt.disclosures!
+        const requiredDisclosures = await getDisclosuresForPresentationFrame(
+            sdJwt.payload!,
+            {
+                nested_field: {
+                    more_nested_field: { a: [true, false, false, true] }
+                },
+                credential: {
+                    ageOver21: true,
+                    firstName: true,
+                    lastName: true
+                },
+                mustDiscloseWholeObject: true
+            },
+            await sdJwt.getPrettyClaims(),
+            (data) => Buffer.from(data),
+            disclosures
+        )
+
+        deepStrictEqual(requiredDisclosures, [
+            disclosures[1],
+            disclosures[3],
+            disclosures[5],
+            disclosures[7],
+            disclosures[8],
+            disclosures[9]
+        ])
+    })
+})

--- a/tests/sdJwt.test.ts
+++ b/tests/sdJwt.test.ts
@@ -837,7 +837,9 @@ describe('sd-jwt', async () => {
                     }
                 }
             )
-            const presentation = await sdJwt.present([1])
+            const presentation = await sdJwt.present({
+                age_over_24: true
+            })
 
             const sdJwtFromCompact =
                 SdJwt.fromCompact(presentation).withHasher(hasherAndAlgorithm)
@@ -1158,7 +1160,9 @@ describe('sd-jwt', async () => {
                 .withSaltGenerator(() => 'salt')
                 .withHasher(hasherAndAlgorithm)
 
-            const presentation = await sdJwt.present([0])
+            const presentation = await sdJwt.present({
+                sign: true
+            })
 
             strictEqual(
                 presentation,
@@ -1176,7 +1180,7 @@ describe('sd-jwt', async () => {
                 .withSaltGenerator(() => 'salt')
                 .withHasher(hasherAndAlgorithm)
 
-            const presentation = await sdJwt.present([])
+            const presentation = await sdJwt.present({})
 
             strictEqual(
                 presentation,
@@ -1184,33 +1188,7 @@ describe('sd-jwt', async () => {
             )
         })
 
-        it('error when the highest index is above the length of the disclosure array', async () => {
-            const sdJwt = new SdJwt({
-                header: { alg: SignatureAndEncryptionAlgorithm.EdDSA },
-                payload: { sign: 'me!!', discloseMe: 'please' }
-            })
-                .withDisclosureFrame({ sign: true, discloseMe: true })
-                .withSigner(() => new Uint8Array(32).fill(42))
-                .withSaltGenerator(() => 'salt')
-                .withHasher(hasherAndAlgorithm)
-
-            await rejects(async () => await sdJwt.present([1000]), SdJwtError)
-        })
-
-        it('error when the same index is supplied twice', async () => {
-            const sdJwt = new SdJwt({
-                header: { alg: SignatureAndEncryptionAlgorithm.EdDSA },
-                payload: { sign: 'me!!', discloseMe: 'please' }
-            })
-                .withDisclosureFrame({ sign: true, discloseMe: true })
-                .withSigner(() => new Uint8Array(32).fill(42))
-                .withSaltGenerator(() => 'salt')
-                .withHasher(hasherAndAlgorithm)
-
-            await rejects(async () => await sdJwt.present([0, 0]), SdJwtError)
-        })
-
-        it('error when there are more indices than disclosable items', async () => {
+        it('error when the presenation frame contains other values than object, array or boolean', async () => {
             const sdJwt = new SdJwt({
                 header: { alg: SignatureAndEncryptionAlgorithm.EdDSA },
                 payload: { sign: 'me!!', discloseMe: 'please' }
@@ -1221,38 +1199,15 @@ describe('sd-jwt', async () => {
                 .withHasher(hasherAndAlgorithm)
 
             await rejects(
-                async () => await sdJwt.present([0, 1, 2, 4]),
+                async () =>
+                    await sdJwt.present({
+                        name: 'string'
+                    }),
                 SdJwtError
             )
         })
 
-        it('error when a negative number is used', async () => {
-            const sdJwt = new SdJwt({
-                header: { alg: SignatureAndEncryptionAlgorithm.EdDSA },
-                payload: { sign: 'me!!', discloseMe: 'please' }
-            })
-                .withDisclosureFrame({ sign: true, discloseMe: true })
-                .withSigner(() => new Uint8Array(32).fill(42))
-                .withSaltGenerator(() => 'salt')
-                .withHasher(hasherAndAlgorithm)
-
-            await rejects(async () => await sdJwt.present([-1]), SdJwtError)
-        })
-
-        it('error when NaN is used', async () => {
-            const sdJwt = new SdJwt({
-                header: { alg: SignatureAndEncryptionAlgorithm.EdDSA },
-                payload: { sign: 'me!!', discloseMe: 'please' }
-            })
-                .withDisclosureFrame({ sign: true, discloseMe: true })
-                .withSigner(() => new Uint8Array(32).fill(42))
-                .withSaltGenerator(() => 'salt')
-                .withHasher(hasherAndAlgorithm)
-
-            await rejects(async () => await sdJwt.present([NaN]), SdJwtError)
-        })
-
-        it('error when infinity is used', async () => {
+        it('error when the presenation frame does not match the structure of the sd-jwt payload', async () => {
             const sdJwt = new SdJwt({
                 header: { alg: SignatureAndEncryptionAlgorithm.EdDSA },
                 payload: { sign: 'me!!', discloseMe: 'please' }
@@ -1263,7 +1218,10 @@ describe('sd-jwt', async () => {
                 .withHasher(hasherAndAlgorithm)
 
             await rejects(
-                async () => await sdJwt.present([Infinity]),
+                async () =>
+                    await sdJwt.present({
+                        name: true
+                    }),
                 SdJwtError
             )
         })

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -7,7 +7,7 @@ import { prelude } from './utils'
 
 const deleteByPathTestGenerator = (
     title: string,
-    path: string,
+    path: string[],
     obj: Record<string, unknown>,
     expected: Record<string, unknown>
 ) => {
@@ -21,41 +21,41 @@ describe('utils', () => {
     before(prelude)
 
     describe('delete by path', () => {
-        deleteByPathTestGenerator('simple path', 'a', { a: 123 }, {})
+        deleteByPathTestGenerator('simple path', ['a'], { a: 123 }, {})
 
-        deleteByPathTestGenerator('empty path', '', { a: 123 }, { a: 123 })
+        deleteByPathTestGenerator('empty path', [], { a: 123 }, { a: 123 })
 
         deleteByPathTestGenerator(
             'nested path',
-            'a.b',
+            ['a', 'b'],
             { a: { b: 123 } },
             { a: {} }
         )
 
         deleteByPathTestGenerator(
             'triple nested path',
-            'a.b.c',
+            ['a', 'b', 'c'],
             { a: { b: { c: 123 } } },
             { a: { b: {} } }
         )
 
         deleteByPathTestGenerator(
             'nested path, delete parent',
-            'a',
+            ['a'],
             { a: { b: 123 } },
             {}
         )
 
         deleteByPathTestGenerator(
             'triple nested path, delete parent',
-            'a',
+            ['a'],
             { a: { b: { c: 123 } } },
             {}
         )
 
         deleteByPathTestGenerator(
             'path does not exist',
-            'abc',
+            ['abc'],
             { a: 123 },
             { a: 123 }
         )


### PR DESCRIPTION
Adds support for presentation frame in the `.present` method.

The logic in this PR already supports recursive disclosures in the presentation frame, so if #2 gets resolved, this could should not require any code changes.

There's two things that could probably be improved upon here:
- add more tests, especially for the lower level methods
- integrate the new method more with the existing code. I think this library will benefit from having some base util methods to traverse payloads/disclosures/etc...
- currently you need to pass the hasher method everywhere. I already added a memoization so that if a disclosure is hashed once, it won't re-hash every time, but  I think there will be benefit in create a disclosure type that stores the digest within the disclosure

Fixes #1 