### PR TITLE
fix: verify result should be false if error

### DIFF
--- a/packages/core/src/sdJwtVc/sdJwtVc.ts
+++ b/packages/core/src/sdJwtVc/sdJwtVc.ts
@@ -6,7 +6,7 @@ import { sdJwtVcFromCompact } from '@sd-jwt/decode'
 import { KeyBinding } from '../keyBinding'
 
 export type SdJwtVcVerificationResult = SdJwtVerificationResult & {
-    containsExpectedKeyBinding: boolean
+    containsExpectedKeyBinding?: boolean
     containsRequiredVcProperties: boolean
 }
 
@@ -138,6 +138,9 @@ export class SdJwtVc<
             } else {
                 sdJwtVerificationResult.containsRequiredVcProperties = false
             }
+
+            // The verification result is not valid if an error occurred
+            sdJwtVerificationResult.isValid = false
         }
 
         return sdJwtVerificationResult

--- a/packages/core/tests/sdJwtVc.test.ts
+++ b/packages/core/tests/sdJwtVc.test.ts
@@ -593,7 +593,7 @@ describe('sd-jwt-vc', async () => {
             })
         })
 
-        it('Validate the sd-jwt-vc with cnf and keybinding, where cnf does not match the expected cnf', async () => {
+        it('Validate the sd-jwt-vc with cnf and keybinding', async () => {
             const cnf = publicHolderKeyJwk
 
             const keyBinding = await new KeyBinding({
@@ -687,7 +687,8 @@ describe('sd-jwt-vc', async () => {
                 isKeyBindingValid: true
             })
         })
-        it('Validate the sd-jwt-vc with cnf and keybinding', async () => {
+
+        it('Validate the sd-jwt-vc with cnf and keybinding, where cnf does not match the expected cnf', async () => {
             const cnf = publicHolderKeyJwk
 
             const keyBinding = await new KeyBinding({
@@ -781,7 +782,7 @@ describe('sd-jwt-vc', async () => {
                 containsRequiredVcProperties: true,
                 containsExpectedKeyBinding: false,
                 isSignatureValid: true,
-                isValid: true,
+                isValid: false,
                 isKeyBindingValid: true
             })
         })


### PR DESCRIPTION
The `isValid` value of `SdJwtVc.verify` return object would be true, if though `containsRequiredVcProperties` or `containsExpectedKeyBinding` could be false. 

I think `isValid` should only be true if all checks and validation have passed, so I made this PR to make it so that it is true. There is a test that tested the flow as it used to be (`isValid: true`, but other fields having `false` value), so if it was on purpose I think we should maybe reconsider it, as it was kinda confusing.

How I've handled it in the past is to create a nested validation object, to separate the overall check (isValid) from the individual checks:

```
{
  // will only be true if all validations are true
  isValid: true,
  validations: {
     containsRequiredVcProperties: true
  }
}
```