### PR TITLE
fix: sd-jwt without disclosures and must have ~

### DIFF
--- a/packages/core/tests/sdJwt.test.ts
+++ b/packages/core/tests/sdJwt.test.ts
@@ -123,7 +123,7 @@ describe('sd-jwt', async () => {
                 signature: Uint8Array.from([1, 2, 3])
             }).toCompact()
 
-            deepStrictEqual(sdJwt, 'eyJraWQiOiAiYSJ9.eyJleHAiOiAxMjN9.AQID')
+            deepStrictEqual(sdJwt, 'eyJraWQiOiAiYSJ9.eyJleHAiOiAxMjN9.AQID~')
         })
 
         it('should create a simple jwt with builder', async () => {
@@ -133,7 +133,7 @@ describe('sd-jwt', async () => {
                 .withSignature(Uint8Array.from([1, 2, 3]))
                 .toCompact()
 
-            deepStrictEqual(sdJwt, 'eyJraWQiOiAiYSJ9.eyJleHAiOiAxMjN9.AQID')
+            deepStrictEqual(sdJwt, 'eyJraWQiOiAiYSJ9.eyJleHAiOiAxMjN9.AQID~')
         })
 
         it('should create a simple jwt with builder', async () => {
@@ -143,7 +143,7 @@ describe('sd-jwt', async () => {
                 .withSignature(Uint8Array.from([1, 2, 3]))
                 .toCompact()
 
-            deepStrictEqual(sdJwt, 'eyJraWQiOiAiYSJ9.eyJleHAiOiAxMjN9.AQID')
+            deepStrictEqual(sdJwt, 'eyJraWQiOiAiYSJ9.eyJleHAiOiAxMjN9.AQID~')
         })
 
         it('should create a simple jwt with add builder', async () => {
@@ -153,12 +153,12 @@ describe('sd-jwt', async () => {
                 .withSignature(Uint8Array.from([1, 2, 3]))
                 .toCompact()
 
-            deepStrictEqual(sdJwt, 'eyJraWQiOiAiYSJ9.eyJleHAiOiAxMjN9.AQID')
+            deepStrictEqual(sdJwt, 'eyJraWQiOiAiYSJ9.eyJleHAiOiAxMjN9.AQID~')
         })
 
         it('should create an instance of sdJwt from a compact sdJwt', async () => {
             const sdJwt = SdJwt.fromCompact<{ kid: string }, { exp: number }>(
-                'eyJraWQiOiJhIn0.eyJleHAiOjEyM30.AQID'
+                'eyJraWQiOiJhIn0.eyJleHAiOjEyM30.AQID~'
             )
 
             deepStrictEqual(sdJwt.header.kid, 'a')
@@ -432,7 +432,6 @@ describe('sd-jwt', async () => {
             )
 
             const compactSdJwt = await sdJwt.toCompact()
-
             assert(!compactSdJwt.endsWith('~'))
 
             strictEqual(
@@ -1212,7 +1211,7 @@ describe('sd-jwt', async () => {
 
             strictEqual(
                 presentation,
-                'eyJhbGciOiAiRWREU0EifQ.eyJfc2RfYWxnIjogInNoYS0yNTYiLCAiX3NkIjogWyJJVlVxckNOcGl4SGxyYlo2S2JrNUxtcTFIdUcxS2Z2UXVZSkNONk9sTjNNIiwgIm9jTDJOTXhwVTBWR240clptbVFaUFZObU1RNTVsZlFTMlBmMkh1Y2s5amMiXX0.KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKio'
+                'eyJhbGciOiAiRWREU0EifQ.eyJfc2RfYWxnIjogInNoYS0yNTYiLCAiX3NkIjogWyJJVlVxckNOcGl4SGxyYlo2S2JrNUxtcTFIdUcxS2Z2UXVZSkNONk9sTjNNIiwgIm9jTDJOTXhwVTBWR240clptbVFaUFZObU1RNTVsZlFTMlBmMkh1Y2s5amMiXX0.KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKio~'
             )
         })
 

--- a/packages/decode/tests/jwtFromCompact.test.ts
+++ b/packages/decode/tests/jwtFromCompact.test.ts
@@ -4,7 +4,7 @@ import { deepStrictEqual, throws } from 'node:assert'
 import { jwtFromCompact } from '../src/jwt'
 
 describe('jwt from compact', () => {
-    describe('succesful decoding of compact jwt', () => {
+    describe('successful decoding of compact jwt', () => {
         it('simple jwt 01', () => {
             const compact =
                 'eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUub3JnIn0.KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKio'

--- a/packages/decode/tests/sdJwtFromCompact.test.ts
+++ b/packages/decode/tests/sdJwtFromCompact.test.ts
@@ -1,0 +1,109 @@
+import { describe, it } from 'node:test'
+import { deepStrictEqual, throws } from 'node:assert'
+
+import { sdJwtFromCompact } from '../src/sdJwt'
+
+describe('sd-jwt from compact', () => {
+    describe('successful decoding of compact jwt', () => {
+        it('simple sd-jwt without disclosures or kb-jwt', () => {
+            const compact =
+                'eyJhbGciOiAiRWREU0EifQ.eyJpc3MiOiAiaHR0cHM6Ly9leGFtcGxlLm9yZy9pc3N1ZXIifQ.KSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSk~'
+
+            const decoded = sdJwtFromCompact(compact)
+
+            deepStrictEqual(decoded, {
+                header: { alg: 'EdDSA' },
+                payload: { iss: 'https://example.org/issuer' },
+                signature: new Uint8Array(32).fill(41)
+            })
+        })
+
+        it('simple sd-jwt without disclosures with kb-jwt', () => {
+            const compact =
+                'eyJhbGciOiAiRWREU0EifQ.eyJpc3MiOiAiaHR0cHM6Ly9leGFtcGxlLm9yZy9pc3N1ZXIifQ.KSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSk~eyJ0eXAiOiAia2Irand0IiwgImFsZyI6ICJFUzI1NiJ9.eyJpYXQiOiAxMjMsIm5vbmNlIjogInNlY3VyZS1ub25jZSIsICJhdWQiOiAiaHR0cHM6Ly9leGFtcGxlLm9yZy9hdWRpZW5jZSJ9.KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKio'
+
+            const decoded = sdJwtFromCompact(compact)
+
+            deepStrictEqual(decoded, {
+                header: { alg: 'EdDSA' },
+                payload: { iss: 'https://example.org/issuer' },
+                signature: new Uint8Array(32).fill(41),
+                keyBinding: {
+                    header: {
+                        typ: 'kb+jwt',
+                        alg: 'ES256'
+                    },
+                    payload: {
+                        iat: 123,
+                        nonce: 'secure-nonce',
+                        aud: 'https://example.org/audience'
+                    },
+                    signature: new Uint8Array(32).fill(42)
+                },
+                disclosures: []
+            })
+        })
+
+        it('simple sd-jwt with disclosures without kb-jwt', () => {
+            const compact =
+                'eyJhbGciOiAiRWREU0EifQ.eyJfc2RfYWxnIjogInNoYS0yNTYiLCAiX3NkIjogWyJhR0Z6YUEiLCAiYUdGemFBIl19.KSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSk~WyJzYWx0IiwgImlzcyIsICJodHRwczovL2V4YW1wbGUub3JnL2lzc3VlciJd~'
+
+            const decoded = sdJwtFromCompact(compact)
+
+            deepStrictEqual(decoded, {
+                header: { alg: 'EdDSA' },
+                payload: { _sd_alg: 'sha-256', _sd: ['aGFzaA', 'aGFzaA'] },
+                signature: new Uint8Array(32).fill(41),
+                keyBinding: undefined,
+                disclosures: [
+                    {
+                        key: 'iss',
+                        salt: 'salt',
+                        value: 'https://example.org/issuer'
+                    }
+                ]
+            })
+        })
+
+        it('simple sd-jwt with disclosures with kb-jwt', () => {
+            const compact =
+                'eyJhbGciOiAiRWREU0EifQ.eyJfc2RfYWxnIjogInNoYS0yNTYiLCAiX3NkIjogWyJhR0Z6YUEiLCAiYUdGemFBIl19.KSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSk~WyJzYWx0IiwgImlzcyIsICJodHRwczovL2V4YW1wbGUub3JnL2lzc3VlciJd~eyJ0eXAiOiAia2Irand0IiwgImFsZyI6ICJFUzI1NiJ9.eyJpYXQiOiAxMjMsIm5vbmNlIjogInNlY3VyZS1ub25jZSIsICJhdWQiOiAiaHR0cHM6Ly9leGFtcGxlLm9yZy9hdWRpZW5jZSJ9.KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKio'
+
+            const decoded = sdJwtFromCompact(compact)
+
+            deepStrictEqual(decoded, {
+                header: { alg: 'EdDSA' },
+                payload: { _sd_alg: 'sha-256', _sd: ['aGFzaA', 'aGFzaA'] },
+                signature: new Uint8Array(32).fill(41),
+                keyBinding: {
+                    header: {
+                        typ: 'kb+jwt',
+                        alg: 'ES256'
+                    },
+                    payload: {
+                        iat: 123,
+                        nonce: 'secure-nonce',
+                        aud: 'https://example.org/audience'
+                    },
+                    signature: new Uint8Array(32).fill(42)
+                },
+                disclosures: [
+                    {
+                        key: 'iss',
+                        salt: 'salt',
+                        value: 'https://example.org/issuer'
+                    }
+                ]
+            })
+        })
+    })
+
+    describe('failed decoding of compact sd-jwt', () => {
+        it('do not allow jwt', () => {
+            const compact =
+                'eyJraWQiOiJhIn0.eyJleHAiOjEyM30.KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKio'
+
+            throws(() => sdJwtFromCompact(compact), Error)
+        })
+    })
+})


### PR DESCRIPTION
According to the spec and as also highlighten in this discussion, an SD-JWT without disclosures or kb-jwt must have a trailing `~`

https://github.com/oauth-wg/oauth-selective-disclosure-jwt/issues/375

