### PR TITLE
fix: support typescript below 5

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,2 +1,2 @@
-export type * from './disclosure'
-export type * from './hasher'
+export * from './disclosure'
+export * from './hasher'


### PR DESCRIPTION
`export type *` is a typescript 5+ feature, and to not have to update the TS version for AFJ + all sphereon libraries I think it's easiest to just support TS < 5 by changing these two lines