### PR TITLE
feat: include encoded disclosure

### DIFF
--- a/packages/decode/src/disclosures/fromArray.ts
+++ b/packages/decode/src/disclosures/fromArray.ts
@@ -1,6 +1,8 @@
 import { Disclosure, DisclosureArray } from '@sd-jwt/types'
 
-export const disclosureFromArray = (a: DisclosureArray): Disclosure =>
+export const disclosureFromArray = (
+    a: DisclosureArray
+): Omit<Disclosure, 'encoded'> =>
     a[2]
         ? { salt: a[0], key: a[1] as string, value: a[2] }
         : { salt: a[0], value: a[1] }

--- a/packages/decode/src/disclosures/fromString.ts
+++ b/packages/decode/src/disclosures/fromString.ts
@@ -4,5 +4,5 @@ import { disclosureFromArray } from './fromArray'
 
 export const disclosureFromString = (s: string): Disclosure => {
     const item = Base64url.decodeToJson<DisclosureArray>(s)
-    return disclosureFromArray(item)
+    return { ...disclosureFromArray(item), encoded: s }
 }

--- a/packages/decode/tests/decode.test.ts
+++ b/packages/decode/tests/decode.test.ts
@@ -80,30 +80,36 @@ describe('decode sd jwt vc', () => {
                     salt: 'salt',
                     key: 'is_over_65',
                     value: true,
+                    encoded: 'WyJzYWx0IiwiaXNfb3Zlcl82NSIsdHJ1ZV0',
                     digest: 'sN_ge0pHXF6qmsYnX1A9SdwJ8ch8aENkxbODsT74YwI'
                 },
                 {
                     salt: 'salt',
                     key: 'is_over_21',
                     value: true,
+                    encoded: 'WyJzYWx0IiwiaXNfb3Zlcl8yMSIsdHJ1ZV0',
                     digest: 'R1zTUvOYHgcepj0jHypGHz9EHttVKft0yswbc9ETPbU'
                 },
                 {
                     salt: 'salt',
                     key: 'email',
                     value: 'johndoe@example.com',
+                    encoded:
+                        'WyJzYWx0IiwiZW1haWwiLCJqb2huZG9lQGV4YW1wbGUuY29tIl0',
                     digest: 'psauKUNWEi09nu3Cl89xKXgmpWENZl5uy1N1nyn_jMk'
                 },
                 {
                     salt: 'salt',
                     key: 'country',
                     value: 'US',
+                    encoded: 'WyJzYWx0IiwiY291bnRyeSIsIlVTIl0',
                     digest: 'om5ZztZHB-Gd00LG21CV_xM4FaENSoiaOXnTAJNczB4'
                 },
                 {
                     salt: 'salt',
                     key: 'given_name',
                     value: 'John',
+                    encoded: 'WyJzYWx0IiwiZ2l2ZW5fbmFtZSIsIkpvaG4iXQ',
                     digest: 'eDqQpdTXJXbWhf-EsI7zw5X6OvYmFN-UZQQMesXwKPw'
                 }
             ],

--- a/packages/decode/tests/sdJwtFromCompact.test.ts
+++ b/packages/decode/tests/sdJwtFromCompact.test.ts
@@ -59,7 +59,9 @@ describe('sd-jwt from compact', () => {
                     {
                         key: 'iss',
                         salt: 'salt',
-                        value: 'https://example.org/issuer'
+                        value: 'https://example.org/issuer',
+                        encoded:
+                            'WyJzYWx0IiwgImlzcyIsICJodHRwczovL2V4YW1wbGUub3JnL2lzc3VlciJd'
                     }
                 ]
             })
@@ -91,7 +93,9 @@ describe('sd-jwt from compact', () => {
                     {
                         key: 'iss',
                         salt: 'salt',
-                        value: 'https://example.org/issuer'
+                        value: 'https://example.org/issuer',
+                        encoded:
+                            'WyJzYWx0IiwgImlzcyIsICJodHRwczovL2V4YW1wbGUub3JnL2lzc3VlciJd'
                     }
                 ]
             })

--- a/packages/types/src/disclosure.ts
+++ b/packages/types/src/disclosure.ts
@@ -4,6 +4,7 @@ export type Disclosure = {
     salt: string
     key?: string
     value: unknown
+    encoded: string
 }
 
 export type DisclosureWithDigest = Disclosure & { digest: string }


### PR DESCRIPTION
So we can match it to the encoded disclosure from the SD-JWT without having to re-base64url the decoded disclosure