### PR TITLE
feat: allow passing issuer and kb jwk

### DIFF
--- a/packages/core/src/sdJwt/sdJwt.ts
+++ b/packages/core/src/sdJwt/sdJwt.ts
@@ -430,20 +430,22 @@ export class SdJwt<
     public async verify(
         verifier: Verifier<Header>,
         requiredClaimKeys?: Array<keyof Payload | string>,
-        publicKeyJwk?: Record<string, unknown>
+        kbJwtPublicKeyJwk?: Record<string, unknown>,
+        issuerPublicKeyJwk?: Record<string, unknown>
     ): Promise<SdJwtVerificationResult> {
         this.assertSignature()
 
         const jwtVerificationResult = (await super.verify(
             verifier,
-            requiredClaimKeys
+            requiredClaimKeys,
+            issuerPublicKeyJwk
         )) as SdJwtVerificationResult
 
         if (this.keyBinding) {
             const { isValid } = await this.keyBinding.verify(
                 verifier as Verifier,
                 [],
-                publicKeyJwk
+                kbJwtPublicKeyJwk
             )
 
             jwtVerificationResult.isKeyBindingValid = isValid

--- a/packages/core/src/sdJwtVc/sdJwtVc.ts
+++ b/packages/core/src/sdJwtVc/sdJwtVc.ts
@@ -123,16 +123,21 @@ export class SdJwtVc<
     public override async verify(
         verifier: Verifier<Header>,
         requiredClaimKeys?: Array<keyof Payload | string>,
-        expectedCnfClaim?: Record<string, unknown>
+        expectedCnfClaim?: Record<string, unknown>,
+        kbJwtPublicKeyJwk?: Record<string, unknown>,
+        issuerPublicKeyJwk?: Record<string, unknown>
     ): Promise<SdJwtVcVerificationResult> {
-        const publicKeyJwk = (
-            this.payload?.cnf as Record<string, unknown> | undefined
-        )?.jwk as Record<string, unknown> | undefined
+        const kbJwtPublicKeyJwkToUse =
+            kbJwtPublicKeyJwk ??
+            ((this.payload?.cnf as Record<string, unknown> | undefined)?.jwk as
+                | Record<string, unknown>
+                | undefined)
 
         const sdJwtVerificationResult = (await super.verify(
             verifier,
             requiredClaimKeys,
-            publicKeyJwk
+            kbJwtPublicKeyJwkToUse,
+            issuerPublicKeyJwk
         )) as SdJwtVcVerificationResult
 
         try {

--- a/packages/core/tests/utils.ts
+++ b/packages/core/tests/utils.ts
@@ -20,6 +20,8 @@ import {
 
 const { publicKey, privateKey } = generateKeyPairSync('ed25519')
 
+export const issuerPublicKeyJwk = publicKey.export({ format: 'jwk' })
+
 export const privateHolderKeyJwk = {
     jwk: {
         crv: 'Ed25519',


### PR DESCRIPTION
This is a 'simple' implementation to allow passing both an expected kb and issuer publicKeyJwk for verification, allowing a `cnf` claim other than `jwk` to be used for verification. 

I think the API is not ideal, but I've done it this way for two reasons:
- It's non-breaking, so it means we can  release it as 0.2.1
- I've tried some things and couldn't get to a good API quickly, and it's quite important to be able to get this working at least manually for now (we can extract the jwk from the did before calling verify). We can then for 0.3 properly rework the API a bit based on discussion in https://github.com/berendsliedrecht/sd-jwt-ts/issues/15

